### PR TITLE
Update sampledata API in template.ipynb

### DIFF
--- a/template.ipynb
+++ b/template.ipynb
@@ -98,7 +98,7 @@
     "function get_sample_data_sync(experiment_id)\n",
     "    println(\"Preparing download file\")\n",
     "    while true\n",
-    "        rsp = HTTP.get(\"https://dev.coinfer.ai/mcmc/experiment/$(experiment_id)/sampledata/csv\", headers=headers)\n",
+    "        rsp = HTTP.get(\"$(endpoint)/api/object/$(experiment_id)?sampledata=true&fmt=csv\", headers=headers)\n",
     "        rsp_data = JSON.parse(String(rsp.body))\n",
     "        if rsp_data[\"data\"][\"progress\"] == \"done\"\n",
     "            return Downloads.download(rsp_data[\"data\"][\"url\"])\n",


### PR DESCRIPTION
This PR update the URL used in notebook to use the new unified style API to replace the old sampledata API.